### PR TITLE
Improvements for utf-8 support and compilation backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,3 @@
-# Additional ignores in the template environment
-auto/
-*.cod
-*.sbl
-*.sym
-
-*~
-
-*.tgz
-*.zip
-
 ## Core latex/pdflatex auxiliary files:
 *.aux
 *.lof
@@ -122,23 +111,15 @@ acs-*.bib
 *.glsdefs
 *.lzo
 *.lzs
-*.slg
-*.slo
-*.sls
 
 # uncomment this for glossaries-extra (will ignore makeindex's style files!)
-*.ist
-
-# gnuplot
-*.gnuplot
-*.table
+# *.ist
 
 # gnuplottex
 *-gnuplottex-*
 
 # gregoriotex
 *.gaux
-*.glog
 *.gtex
 
 # htlatex
@@ -154,8 +135,8 @@ acs-*.bib
 
 # knitr
 *-concordance.tex
-# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
-# *.tikz
+# TODO Comment the next line if you want to keep your tikz graphics files
+*.tikz
 *-tikzDictionary
 
 # listings
@@ -185,9 +166,6 @@ _minted*
 # morewrites
 *.mw
 
-# newpax
-*.newpax
-
 # nomencl
 *.nlg
 *.nlo
@@ -206,9 +184,6 @@ _minted*
 
 # scrwfile
 *.wrt
-
-# svg
-svg-inkscape/
 
 # sympy
 *.sout
@@ -233,9 +208,6 @@ pythontex-files-*/
 *.dpth
 *.md5
 *.auxlock
-
-# titletoc
-*.ptc
 
 # todonotes
 *.tdo
@@ -303,10 +275,259 @@ TSWLatexianTemp*
 # Makeindex log files
 *.lpz
 
-# xwatermark package
-*.xwm
 
-# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
-# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
-# Uncomment the next line to have this generated file ignored.
-#*Notes.bib
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+# Ignore LyX backup and autosave files
+# http://www.lyx.org/
+*.lyx~
+*.lyx#
+
+
+  
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# Backup files 
+*.bak
+*.gho
+*.ori
+*.orig
+*.tmp
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+ # Diff files
+*.patch
+*.diff
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+## User settings
+xcuserdata/
+
+## Xcode 8 and earlier
+*.xcscmblueprint
+*.xccheckout
+
+# Don't check flatten or diffed files into git
+*flatten*.tex

--- a/Anteproyecto/Makefile
+++ b/Anteproyecto/Makefile
@@ -36,6 +36,16 @@ DIFF_FLATTEN_TEX_FILE = $(DIFF_FLATTEN_ROOT_FILENAME).tex
 RUBBER_TOOL=rubber
 LATEXMK_TOOL=latexmk
 EPSPDF_TOOL=epspdf
+PDF_TOOL=pdflatex
+# PDF_TOOL=xelatex
+# PDF_TOOL=lualatex
+
+ifeq ($(PDF_TOOL),pdflatex)
+	PDF_PREFIX := $(shell echo $(PDF_TOOL) | sed -e "s/latex//")
+else
+	PDF_PREFIX := pdf$(shell echo $(PDF_TOOL) | sed -e "s/latex//" )
+endif
+
 RM=rm -f
 
 BIBLIO_PACKAGE=$(shell cat ../Config/preamble-anteproyecto.tex | grep -e bibliosystem | grep -v ifthenelse | grep newcommand | grep -v "^\%" | cut -d'{' -f3 | cut -d'}' -f1 | tr -d " ")
@@ -66,16 +76,19 @@ all: $(DUMMY_TARGETS) anteproyecto
 #	$(RUBBER_TOOL) -f -d $(TEX_FILE)
 
 anteproyecto: $(TEX_FILENAME)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 #	$(RUBBER_TOOL) -f -d $(TEX_FILE)
 #	$(RUBBER_TOOL) -f -d $(TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 	$(BIBLIO_TOOL) $(ROOT_FILENAME)	
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 
 anteproyecto_latexmk: $(TEX_FILENAME)
-	$(LATEXMK_TOOL) -pdf -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
-	$(LATEXMK_TOOL) -pdf -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
+	# Note: pdflatex/lualatex, etc option when provided with the COMMAND
+	# argument only sets the command for invoking pdflatex; it does not turn on
+	# the use of pdflatex. That is done by other options or in an
+	# initialization file. (Or using -pdf, -xepdf, -luapdf) as specified in $(PDF_TOOL)
+	$(LATEXMK_TOOL) -$(PDF_PREFIX) -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -xelatex="xelatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -lualatex="lualatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
 
 snapshot:
 	latexpand $(TEX_FILE) > $(SNAPSHOT_FLATTEN_TEX_FILE)
@@ -84,15 +97,15 @@ flatten:
 	latexpand $(TEX_FILE) > $(FLATTEN_TEX_FILE)
 
 latexdiff: flatten
-#	latexdiff --encoding=utf8 --config="PICTUREENV=(?:picture|tikzpicture|DIFnomarkup)[\w\d*@]*" $((SNAPSHOT_FLATTEN_TEX_FILE) $(FLATTEN_TEX_FILE)
+	# latexdiff --encoding=utf8 --config="PICTUREENV=(?:picture|tikzpicture|DIFnomarkup)[\w\d*@]*" $((SNAPSHOT_FLATTEN_TEX_FILE) $(FLATTEN_TEX_FILE)
 	latexdiff --encoding=utf8 --config="PICTUREENV=(?:picture|tikzpicture|DIFnomarkup)[\w\d*@]*" $(SNAPSHOT_FLATTEN_TEX_FILE) $(FLATTEN_TEX_FILE) > $(DIFF_FLATTEN_TEX_FILE)
-#latexdiff-git --force -r $(FLATTEN_TEX_FILE)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
 #	$(RUBBER_TOOL) -d $(DIFF_FLATTEN_TEX_FILE)
 #	$(RUBBER_TOOL) -d $(DIFF_FLATTEN_TEX_FILE)
+	# latexdiff-git --force -r $(FLATTEN_TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
 	$(BIBLIO_TOOL)  $(DIFF_FLATTEN_ROOT_FILENAME)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
 
 
 pdf_dia_done: $(PDFS_FROM_DIA)

--- a/Anteproyecto/Makefile
+++ b/Anteproyecto/Makefile
@@ -38,6 +38,13 @@ LATEXMK_TOOL=latexmk
 EPSPDF_TOOL=epspdf
 RM=rm -f
 
+BIBLIO_PACKAGE=$(shell cat ../Config/preamble-anteproyecto.tex | grep -e bibliosystem | grep -v ifthenelse | grep newcommand | grep -v "^\%" | cut -d'{' -f3 | cut -d'}' -f1 | tr -d " ")
+ifeq ($(BIBLIO_PACKAGE),bibtex)
+	BIBLIO_TOOL := bibtex
+else
+	BIBLIO_TOOL := biber
+endif
+
 ###########################################################################
 # Support to automagically compile dia+svg files. Adapt to your own needs
 DIA_SOURCES=$(wildcard ../Book/diagrams/*.dia)
@@ -60,11 +67,11 @@ all: $(DUMMY_TARGETS) anteproyecto
 
 anteproyecto: $(TEX_FILENAME)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
-	bibtex $(ROOT_FILENAME)	
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 #	$(RUBBER_TOOL) -f -d $(TEX_FILE)
 #	$(RUBBER_TOOL) -f -d $(TEX_FILE)
+	$(BIBLIO_TOOL) $(ROOT_FILENAME)	
 
 anteproyecto_latexmk: $(TEX_FILENAME)
 	$(LATEXMK_TOOL) -pdf -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
@@ -81,11 +88,11 @@ latexdiff: flatten
 	latexdiff --encoding=utf8 --config="PICTUREENV=(?:picture|tikzpicture|DIFnomarkup)[\w\d*@]*" $(SNAPSHOT_FLATTEN_TEX_FILE) $(FLATTEN_TEX_FILE) > $(DIFF_FLATTEN_TEX_FILE)
 #latexdiff-git --force -r $(FLATTEN_TEX_FILE)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
-	bibtex  $(DIFF_FLATTEN_ROOT_FILENAME)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
 #	$(RUBBER_TOOL) -d $(DIFF_FLATTEN_TEX_FILE)
 #	$(RUBBER_TOOL) -d $(DIFF_FLATTEN_TEX_FILE)
+	$(BIBLIO_TOOL)  $(DIFF_FLATTEN_ROOT_FILENAME)
 
 
 pdf_dia_done: $(PDFS_FROM_DIA)

--- a/Anteproyecto/Makefile
+++ b/Anteproyecto/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.4 2016/03/31 23:38:15 macias Exp $
 #
 # By:
-#  + Javier Mac�as-Guarasa. 
-#    Departamento de Electr�nica
-#    Universidad de Alcal�
+#  + Javier MacÃ­as-Guarasa. 
+#    Departamento de ElectrÃ³nica
+#    Universidad de AlcalÃ¡
 #  + Roberto Barra-Chicote. 
-#    Departamento de Ingenier�a Electr�nica
-#    Universidad Polit�cnica de Madrid   
+#    Departamento de IngenierÃ­a ElectrÃ³nica
+#    Universidad PolitÃ©cnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel Oca�a, Jes�s Nuevo,
-# Pedro Revenga, Fernando Herr�nz and Noelia Hern�ndez. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel OcaÃ±a, JesÃºs Nuevo,
+# Pedro Revenga, Fernando HerrÃ¡nz and Noelia HernÃ¡ndez. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #

--- a/Anteproyecto/Makefile
+++ b/Anteproyecto/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.4 2016/03/31 23:38:15 macias Exp $
 #
 # By:
-#  + Javier MacÃ­as-Guarasa. 
-#    Departamento de ElectrÃ³nica
-#    Universidad de AlcalÃ¡
+#  + Javier Macías-Guarasa. 
+#    Departamento de Electrónica
+#    Universidad de Alcalá
 #  + Roberto Barra-Chicote. 
-#    Departamento de IngenierÃ­a ElectrÃ³nica
-#    Universidad PolitÃ©cnica de Madrid   
+#    Departamento de Ingeniería Electrónica
+#    Universidad Politécnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel OcaÃ±a, JesÃºs Nuevo,
-# Pedro Revenga, Fernando HerrÃ¡nz and Noelia HernÃ¡ndez. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel Ocaña, Jesús Nuevo,
+# Pedro Revenga, Fernando Herránz and Noelia Hernández. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #
@@ -33,7 +33,6 @@ FLATTEN_TEX_FILE = $(ROOT_FILENAME)-flatten.tex
 SNAPSHOT_FLATTEN_TEX_FILE = $(ROOT_FILENAME)-flatten-snapshot.tex
 DIFF_FLATTEN_ROOT_FILENAME = $(ROOT_FILENAME)-flatten-diff
 DIFF_FLATTEN_TEX_FILE = $(DIFF_FLATTEN_ROOT_FILENAME).tex
-RUBBER_TOOL=rubber
 LATEXMK_TOOL=latexmk
 EPSPDF_TOOL=epspdf
 PDF_TOOL=pdflatex
@@ -68,16 +67,11 @@ PDFS_FROM_EPS=$(patsubst %.eps,%.pdf,$(EPS_SOURCES))
 DUMMY_TARGETS=pdf_dia_done pdf_svg_done pdf_eps_done
 
 # To use synctex 
-FLAGS_SYNCTEX_RUBBER=--synctex
 FLAGS_SYNCTEX_PDFLATEX=-synctex=1
 
 all: $(DUMMY_TARGETS) anteproyecto
-#	$(RUBBER_TOOL) -f -d $(TEX_FILE)
-#	$(RUBBER_TOOL) -f -d $(TEX_FILE)
 
 anteproyecto: $(TEX_FILENAME)
-#	$(RUBBER_TOOL) -f -d $(TEX_FILE)
-#	$(RUBBER_TOOL) -f -d $(TEX_FILE)
 	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 	$(BIBLIO_TOOL) $(ROOT_FILENAME)	
 	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
@@ -99,8 +93,6 @@ flatten:
 latexdiff: flatten
 	# latexdiff --encoding=utf8 --config="PICTUREENV=(?:picture|tikzpicture|DIFnomarkup)[\w\d*@]*" $((SNAPSHOT_FLATTEN_TEX_FILE) $(FLATTEN_TEX_FILE)
 	latexdiff --encoding=utf8 --config="PICTUREENV=(?:picture|tikzpicture|DIFnomarkup)[\w\d*@]*" $(SNAPSHOT_FLATTEN_TEX_FILE) $(FLATTEN_TEX_FILE) > $(DIFF_FLATTEN_TEX_FILE)
-#	$(RUBBER_TOOL) -d $(DIFF_FLATTEN_TEX_FILE)
-#	$(RUBBER_TOOL) -d $(DIFF_FLATTEN_TEX_FILE)
 	# latexdiff-git --force -r $(FLATTEN_TEX_FILE)
 	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_ROOT_FILENAME)
 	$(BIBLIO_TOOL)  $(DIFF_FLATTEN_ROOT_FILENAME)
@@ -142,7 +134,6 @@ tar:
 	zip -u $(ROOT_FILENAME)-latex.zip `find . -name Makefile -o -name README -o -name "*.txt" -o -name "*.ppt*" -o -name "*.c" -o -name "*.sty" -o -name "*.tex" -o -name "*.bib" -o -name "*.pdf" -o -name "*.png" -o -name "*.PNG" -o -name "*.jpg" -o -name "*.JPG" -o -name "*.dia" -o -name "*.eps" -o -name "*.EPS"` 
 
 clean:
-	$(RUBBER_TOOL) --clean -d $(TEX_FILE)
 #	$(RM) $(PDFS_FROM_DIA)
 #	$(RM) $(PDFS_FROM_SVG)
 	$(RM) $(DUMMY_TARGETS)

--- a/Book/Makefile
+++ b/Book/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.22 2016/07/14 23:37:33 macias Exp $
 #
 # By:
-#  + Javier MacÃ­as-Guarasa. 
-#    Departamento de ElectrÃ³nica
-#    Universidad de AlcalÃ¡
+#  + Javier Macías-Guarasa. 
+#    Departamento de Electrónica
+#    Universidad de Alcalá
 #  + Roberto Barra-Chicote. 
-#    Departamento de IngenierÃ­a ElectrÃ³nica
-#    Universidad PolitÃ©cnica de Madrid   
+#    Departamento de Ingeniería Electrónica
+#    Universidad Politécnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel OcaÃ±a, JesÃºs Nuevo,
-# Pedro Revenga, Fernando HerrÃ¡nz and Noelia HernÃ¡ndez. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel Ocaña, Jesús Nuevo,
+# Pedro Revenga, Fernando Herránz and Noelia Hernández. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #
@@ -49,7 +49,6 @@ FLATTEN_TEX_FILE = $(ROOT_FILENAME)-flatten.tex
 SNAPSHOT_FLATTEN_TEX_FILE = $(ROOT_FILENAME)-flatten-snapshot.tex
 DIFF_FLATTEN_ROOT_FILENAME = $(ROOT_FILENAME)-flatten-diff
 DIFF_FLATTEN_TEX_FILE = $(DIFF_FLATTEN_ROOT_FILENAME).tex
-RUBBER_TOOL=rubber
 LATEXMK_TOOL=latexmk
 PDF_TOOL=pdflatex
 EPSPDF_TOOL=epspdf
@@ -93,15 +92,10 @@ DUMMY_TARGETS=pdf_dia_done pdf_svg_done pdf_eps_done
 DATE=$(shell date "+%C%y%m%d-%H%M%S")
 
 # To use synctex 
-FLAGS_SYNCTEX_RUBBER=--synctex
 FLAGS_SYNCTEX_PDFLATEX=-synctex=1
 
 # To generate 
 all: $(DUMMY_TARGETS)
-	# $(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -f -d $(TEX_FILE)
-	# makeglossaries $(ROOT_FILENAME)
-	# $(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -f -d $(TEX_FILE)
-	# Generate pdf metadata
 	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 	$(BIBLIO_TOOL) $(ROOT_FILENAME)
 	makeglossaries $(ROOT_FILENAME)
@@ -110,12 +104,6 @@ all: $(DUMMY_TARGETS)
 	echo $(ROOT_FINAL_BOOK_FILENAME)
 	echo "[$(BOOK_TYPE)][$(DEGREE_NAME)][$(AUTHOR_SURNAME)][$(AUTHOR_NAME)][$(BOOK_LANGUAGE)]"
 	mv $(ROOT_FILENAME).pdf $(ROOT_FINAL_BOOK_FILENAME).pdf
-
-all_old: $(DUMMY_TARGETS)
-	$(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -f -d $(TEX_FILE)
-	makeglossaries $(ROOT_FILENAME)
-	$(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -f -d $(TEX_FILE)
-
 
 bare: backup-chapters bare-chapters clean-orig-figures clean-orig-diagrams
 
@@ -188,9 +176,6 @@ flatten:
 # now. 
 latexdiff: flatten
 	latexdiff --encoding=utf8 --config="PICTUREENV=(?:picture|tikzpicture|DIFnomarkup)[\w\d*@]*" $(SNAPSHOT_FLATTEN_TEX_FILE) $(FLATTEN_TEX_FILE)| sed -e 's/^[ ]*//g' | sed -e 's/[ ]*$$//g' | perl -0777  -pe 's/[}]\n\\end[{]tikzpicture[}];\n\\end[{]tikzpicture[}]/\\end{tikzpicture}\n};\n\\end{tikzpicture}/g' >  $(DIFF_FLATTEN_TEX_FILE)
-#	$(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -d $(DIFF_FLATTEN_TEX_FILE)
-#	makeglossaries $(DIFF_FLATTEN_ROOT_FILENAME)
-#	$(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -d $(DIFF_FLATTEN_TEX_FILE)
 	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
 	$(BIBLIO_TOOL) $(DIFF_FLATTEN_ROOT_FILENAME)
 	makeglossaries $(DIFF_FLATTEN_ROOT_FILENAME)
@@ -236,7 +221,6 @@ tar:
 	zip -u $(ROOT_FILENAME)-latex.zip `find . -name Makefile -o -name README -o -name "*.txt" -o -name "*.ppt*" -o -name "*.c" -o -name "*.sty" -o -name "*.tex" -o -name "*.bib" -o -name "*.pdf" -o -name "*.png" -o -name "*.PNG" -o -name "*.jpg" -o -name "*.JPG" -o -name "*.dia" -o -name "*.eps" -o -name "*.EPS" ` 
 
 clean:
-	$(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) --clean -d $(TEX_FILE)
 #	$(RM) $(PDFS_FROM_DIA)
 #	$(RM) $(PDFS_FROM_SVG)
 	$(RM) $(DUMMY_TARGETS)

--- a/Book/Makefile
+++ b/Book/Makefile
@@ -50,7 +50,6 @@ SNAPSHOT_FLATTEN_TEX_FILE = $(ROOT_FILENAME)-flatten-snapshot.tex
 DIFF_FLATTEN_ROOT_FILENAME = $(ROOT_FILENAME)-flatten-diff
 DIFF_FLATTEN_TEX_FILE = $(DIFF_FLATTEN_ROOT_FILENAME).tex
 LATEXMK_TOOL=latexmk
-PDF_TOOL=pdflatex
 EPSPDF_TOOL=epspdf
 RM=rm -f
 ifeq ($(BIBLIO_PACKAGE),bibtex)
@@ -59,9 +58,9 @@ else
 	BIBLIO_TOOL := biber
 endif
 
-# PDF_TOOL=pdflatex
+PDF_TOOL=pdflatex
 # PDF_TOOL=xelatex
-PDF_TOOL=lualatex
+# PDF_TOOL=lualatex
 
 ifeq ($(PDF_TOOL),pdflatex)
 	PDF_PREFIX := $(shell echo $(PDF_TOOL) | sed -e "s/latex//")

--- a/Book/Makefile
+++ b/Book/Makefile
@@ -51,12 +51,23 @@ DIFF_FLATTEN_ROOT_FILENAME = $(ROOT_FILENAME)-flatten-diff
 DIFF_FLATTEN_TEX_FILE = $(DIFF_FLATTEN_ROOT_FILENAME).tex
 RUBBER_TOOL=rubber
 LATEXMK_TOOL=latexmk
+PDF_TOOL=pdflatex
 EPSPDF_TOOL=epspdf
 RM=rm -f
 ifeq ($(BIBLIO_PACKAGE),bibtex)
 	BIBLIO_TOOL := bibtex
 else
 	BIBLIO_TOOL := biber
+endif
+
+# PDF_TOOL=pdflatex
+# PDF_TOOL=xelatex
+PDF_TOOL=lualatex
+
+ifeq ($(PDF_TOOL),pdflatex)
+	PDF_PREFIX := $(shell echo $(PDF_TOOL) | sed -e "s/latex//")
+else
+	PDF_PREFIX := pdf$(shell echo $(PDF_TOOL) | sed -e "s/latex//" )
 endif
 
 ###########################################################################
@@ -91,12 +102,11 @@ all: $(DUMMY_TARGETS)
 	# makeglossaries $(ROOT_FILENAME)
 	# $(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -f -d $(TEX_FILE)
 	# Generate pdf metadata
-	cat ../Config/$(ROOT_FILENAME).xmpdata.vars | sed "s/__DEGREE__/$degree/g" 
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 	$(BIBLIO_TOOL) $(ROOT_FILENAME)
 	makeglossaries $(ROOT_FILENAME)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 	echo $(ROOT_FINAL_BOOK_FILENAME)
 	echo "[$(BOOK_TYPE)][$(DEGREE_NAME)][$(AUTHOR_SURNAME)][$(AUTHOR_NAME)][$(BOOK_LANGUAGE)]"
 	mv $(ROOT_FILENAME).pdf $(ROOT_FINAL_BOOK_FILENAME).pdf
@@ -158,9 +168,13 @@ clean-orig-diagrams:
 
 
 all_latexmk: $(DUMMY_TARGETS)
-	$(LATEXMK_TOOL) -pdf -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
+	# Note: pdflatex/lualatex, etc option when provided with the COMMAND
+	# argument only sets the command for invoking pdflatex; it does not turn on
+	# the use of pdflatex. That is done by other options or in an
+	# initialization file. (Or using -pdf, -xepdf, -luapdf) as specified in $(PDF_TOOL)
+	$(LATEXMK_TOOL) -$(PDF_PREFIX) -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -xelatex="xelatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -lualatex="lualatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
 	makeglossaries $(ROOT_FILENAME)
-	$(LATEXMK_TOOL) -pdf -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
+	$(LATEXMK_TOOL) -$(PDF_PREFIX) -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -xelatex="xelatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -lualatex="lualatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
 
 snapshot:
 	latexpand $(TEX_FILE) > $(SNAPSHOT_FLATTEN_TEX_FILE)
@@ -177,11 +191,11 @@ latexdiff: flatten
 #	$(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -d $(DIFF_FLATTEN_TEX_FILE)
 #	makeglossaries $(DIFF_FLATTEN_ROOT_FILENAME)
 #	$(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -d $(DIFF_FLATTEN_TEX_FILE)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
 	$(BIBLIO_TOOL) $(DIFF_FLATTEN_ROOT_FILENAME)
 	makeglossaries $(DIFF_FLATTEN_ROOT_FILENAME)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
-	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
 
 
 

--- a/Book/Makefile
+++ b/Book/Makefile
@@ -44,6 +44,7 @@ ROOT_FILENAME=book
 #ROOT_FINAL_BOOK_FILENAME=$(ROOT_FILENAME)-$(DEGREE_NAME)-$(AUTHOR_SURNAME)-$(AUTHOR_NAME)-$(BOOK_LANGUAGE)
 ROOT_FINAL_BOOK_FILENAME=$(BOOK_TYPE)-$(DEGREE_NAME)-$(AUTHOR_SURNAME)-$(AUTHOR_NAME)-$(BOOK_LANGUAGE)
 TEX_FILE = $(ROOT_FILENAME).tex
+BIBLIO_PACKAGE=$(shell cat ../Config/preamble.tex | grep -e bibliosystem | grep -v ifthenelse | grep newcommand | grep -v "^\%" | cut -d'{' -f3 | cut -d'}' -f1 | tr -d " ")
 FLATTEN_TEX_FILE = $(ROOT_FILENAME)-flatten.tex
 SNAPSHOT_FLATTEN_TEX_FILE = $(ROOT_FILENAME)-flatten-snapshot.tex
 DIFF_FLATTEN_ROOT_FILENAME = $(ROOT_FILENAME)-flatten-diff
@@ -52,6 +53,11 @@ RUBBER_TOOL=rubber
 LATEXMK_TOOL=latexmk
 EPSPDF_TOOL=epspdf
 RM=rm -f
+ifeq ($(BIBLIO_PACKAGE),bibtex)
+	BIBLIO_TOOL := bibtex
+else
+	BIBLIO_TOOL := biber
+endif
 
 ###########################################################################
 # Support to automagically compile dia+svg files. Adapt to your own needs
@@ -87,7 +93,7 @@ all: $(DUMMY_TARGETS)
 	# Generate pdf metadata
 	cat ../Config/$(ROOT_FILENAME).xmpdata.vars | sed "s/__DEGREE__/$degree/g" 
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
-	bibtex $(ROOT_FILENAME)
+	$(BIBLIO_TOOL) $(ROOT_FILENAME)
 	makeglossaries $(ROOT_FILENAME)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
@@ -172,7 +178,7 @@ latexdiff: flatten
 #	makeglossaries $(DIFF_FLATTEN_ROOT_FILENAME)
 #	$(RUBBER_TOOL) $(FLAGS_SYNCTEX_RUBBER) -d $(DIFF_FLATTEN_TEX_FILE)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
-	bibtex $(DIFF_FLATTEN_ROOT_FILENAME)
+	$(BIBLIO_TOOL) $(DIFF_FLATTEN_ROOT_FILENAME)
 	makeglossaries $(DIFF_FLATTEN_ROOT_FILENAME)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)
 	pdflatex $(FLAGS_SYNCTEX_PDFLATEX) $(DIFF_FLATTEN_TEX_FILE)

--- a/Book/Makefile
+++ b/Book/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.22 2016/07/14 23:37:33 macias Exp $
 #
 # By:
-#  + Javier Macías-Guarasa. 
-#    Departamento de Electrónica
-#    Universidad de Alcalá
+#  + Javier MacÃƒÂ­as-Guarasa. 
+#    Departamento de ElectrÃƒÂ³nica
+#    Universidad de AlcalÃƒÂ¡
 #  + Roberto Barra-Chicote. 
-#    Departamento de Ingeniería Electrónica
-#    Universidad Politécnica de Madrid   
+#    Departamento de IngenierÃƒÂ­a ElectrÃƒÂ³nica
+#    Universidad PolitÃƒÂ©cnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel Ocaña, Jesús Nuevo,
-# Pedro Revenga, Fernando Herránz and Noelia Hernández. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel OcaÃƒÂ±a, JesÃƒÂºs Nuevo,
+# Pedro Revenga, Fernando HerrÃƒÂ¡nz and Noelia HernÃƒÂ¡ndez. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #
@@ -30,13 +30,13 @@
 SHELL=/bin/bash
 
 DEGREE_NAME=$(shell cat ../Config/myconfig.tex | grep -v "%" | grep "myDegree" | cut -f 3 -d "{"| cut -f 1 -d "}")
-# Here you can use "iconv -f utf8 -t ascii//TRANSLIT test1" or sed "y/áéíóúñüÁÉÍÓÚÑÜ/aeiounuAEIOUNU/"
+# Here you can use "iconv -f utf8 -t ascii//TRANSLIT test1"
 AUTHOR_NAME=$(shell cat ../Config/myconfig.tex | grep -v "%" | grep "myAuthorName" | grep -v "myAuthorFullName" | cut -f 3 -d "{"| cut -f 1 -d "}" | tr -d " ")
 AUTHOR_SURNAME=$(shell cat ../Config/myconfig.tex | grep -v "%" | grep "myAuthorSurname" | grep -v "myAuthorFullName" | cut -f 3 -d "{"| cut -f 1 -d "}" | tr -d " ")
 BOOK_LANGUAGE=$(shell cat ../Config/myconfig.tex | grep -v "%" | grep "myLanguage" | cut -f 3 -d "{"| cut -f 1 -d "}")
 BOOK_TYPE=$(shell cat ../Config/worktypes.txt | grep -w $(DEGREE_NAME) | tr -s " " | cut -f 2 -d " " | tr -d " ")
 
-#TENGO QUE VER SÓMO GENERAR EL XMPDATA PARA INCLUIRLO... GENERO ERROR APOSTA...
+#TENGO QUE VER COMO GENERAR EL XMPDATA PARA INCLUIRLO... GENERO ERROR APOSTA...
 TFX_TITLE=$(shell cat ../Config/myconfig.tex | grep -v "%" | grep "myBookTitle" | cut -f 3 -d "{"| cut -f 1 -d "}")
 
 

--- a/Book/appendix/function.c
+++ b/Book/appendix/function.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-// Esto es una función de prueba
+// Esto es una funciÃ³n de prueba
 void funcionPrueba(int argumento)
 {	
 	int prueba = 1;

--- a/Book/appendix/manual.tex
+++ b/Book/appendix/manual.tex
@@ -76,10 +76,11 @@ ejemplo \ref{cod:sample1}, usando
 \texttt{Cbluebox} (además de usar el entorno \texttt{codefloat} para
 evitar pagebreaks, etc.).
 
+% \inputencoding{latin1}
+% \inputencoding{utf8}
+
 \begin{codefloat}
-\inputencoding{latin1}
 \lstinputlisting[style=Cbluebox]{appendix/function.c}
-\inputencoding{utf8}
 \caption{Ejemplo de código fuente con un \texttt{lstinputlisting} dentro
 de un \texttt{codefloat}}
 \label{cod:sample1}

--- a/Book/biblio/biblio.bib
+++ b/Book/biblio/biblio.bib
@@ -252,6 +252,7 @@ Practical aspects of microphone array signal processing},
   year =	 1990
 }
 @Book{o'shaughnessy50,
+@Book{oshaughnessy50,
   author =	 {Douglas O'Shaughnessy},
   title = 	 {Speech Communication Human and Machine},
   publisher = 	 {Addison-Wesley},

--- a/Book/biblio/biblio.bib
+++ b/Book/biblio/biblio.bib
@@ -259,14 +259,14 @@ Practical aspects of microphone array signal processing},
   series =	 {Electrical Engineering: Digital Signal Processing}
 }
 @PhdThesis{cordoba95,
-  author = 	 {Ricardo de Córdoba Herralde},
-  title = 	 {Sistemas de reconocimiento de habla continua y aislada: comparación y optimización de los sistemas de modelado y parametrización},
+  author = 	 {Ricardo de CÃ³rdoba Herralde},
+  title = 	 {Sistemas de reconocimiento de habla continua y aislada: comparaciÃ³n y optimizaciÃ³n de los sistemas de modelado y parametrizaciÃ³n},
   school = 	 {ETSIT, UPM},
   year = 	 1995,
   type =	 {Tesis doctoral}
 }
 @PhdThesis{guarasa92,
-  author = 	 {Javier Macías Guarasa},
+  author = 	 {Javier MacÃ­as Guarasa},
   title = 	 {Desarrollo de un sistema de reconocimiento de palabras aisladas, de gran vocabulario, dependiente del locutor, en tiempo real sobre PC},
   school = 	 {ETSIT, UPM},
   year = 	 1992,
@@ -274,86 +274,86 @@ Practical aspects of microphone array signal processing},
   address =	 {Madrid}
 }
 @Misc{isip,
-  note =	 {\url{http://www.isip.msstate.edu/projects/speech/index.html} [Último acceso 4/mayo/2021]},
-  title =	 {Página de ISIP (Institute for Signal and Information Processing, universidad de Mississippi)}
+  note =	 {\url{http://www.isip.msstate.edu/projects/speech/index.html} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de ISIP (Institute for Signal and Information Processing, universidad de Mississippi)}
 }
 @Misc{cmu,
-  note =	 {\url{http://www.speech.cs.cmu.edu} [Último acceso 4/mayo/2021]},
-  title =	 {Página de CMU (Carnegie Melon University)}
+  note =	 {\url{http://www.speech.cs.cmu.edu} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de CMU (Carnegie Melon University)}
 }
 
 @Misc{cslu,
-  note =	 {\url{http://cslu.cse.ogi.edu} [Último acceso 4/mayo/2021]},
-  title =	 {Página de CSLU (Center for Spoken Language Understanding) de OGI (Oregon Graduate Institute of Science and Technology)}
+  note =	 {\url{http://cslu.cse.ogi.edu} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de CSLU (Center for Spoken Language Understanding) de OGI (Oregon Graduate Institute of Science and Technology)}
 }
 
 @Misc{asp,
-  note =	 {\url{http://www.asp.ogi.edu} [Último acceso 4/mayo/2021]},
-  title =	 {Página del grupo ASP de OGI (Oregon Graduate Institute of Science and Technology)}
+  note =	 {\url{http://www.asp.ogi.edu} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina del grupo ASP de OGI (Oregon Graduate Institute of Science and Technology)}
 }
 
 @Misc{fftw,
-  note =	 {\url{http://www.fftw.org} [Último acceso 4/mayo/2021]},
-  title =	 {Página sobre FFT}
+  note =	 {\url{http://www.fftw.org} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina sobre FFT}
 }
 
 @Misc{djbfft,
-  note =	 {\url{http://cr.yp.to/djbfft.html} [Último acceso 4/mayo/2021]},
-  title =	 {Página sobre FFT}
+  note =	 {\url{http://cr.yp.to/djbfft.html} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina sobre FFT}
 }
 
 @Misc{icsi,
-  note =	 {\url{http://www.icsi.berkeley.edu} [Último acceso 4/mayo/2021]},
-  title =	 {Página de ICSI (International Computer Science Institute) de Berkeley (California)}
+  note =	 {\url{http://www.icsi.berkeley.edu} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de ICSI (International Computer Science Institute) de Berkeley (California)}
 }
 
 @Misc{octave,
-  note =	 {\url{http://www.octave.org} [Último acceso 4/mayo/2021]},
-  title =	 {Página de la aplicación Octave}
+  note =	 {\url{http://www.octave.org} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de la aplicaciÃ³n Octave}
 }
 
 @Misc{kdevelop,
-  note =	 {\url{http://www.kdevelop.org} [Último acceso 4/mayo/2021]},
-  title =	 {Página de la aplicación KDevelop}
+  note =	 {\url{http://www.kdevelop.org} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de la aplicaciÃ³n KDevelop}
 }
 
 
 @Misc{cvs,
-  note =	 {\url{http://savannah.nongnu.org/projects/cvs/} [Último acceso 4/mayo/2021]},
-  title =	 {Página de la aplicación CVS}
+  note =	 {\url{http://savannah.nongnu.org/projects/cvs/} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de la aplicaciÃ³n CVS}
 }
 
 @Misc{make,
-  note =	 {\url{http://savannah.gnu.org/projects/make/} [Último acceso 4/mayo/2021]},
-  title =	 {Página de la aplicación make}
+  note =	 {\url{http://savannah.gnu.org/projects/make/} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de la aplicaciÃ³n make}
 }
 
 @Misc{emacs,
-  note =	 {\url{http://savannah.gnu.org/projects/emacs/} [Último acceso 4/mayo/2021]},
-  title =	 {Página de la aplicación emacs}
+  note =	 {\url{http://savannah.gnu.org/projects/emacs/} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de la aplicaciÃ³n emacs}
 }
 
 @Misc{gcc,
-  note =	 {\url{http://savannah.gnu.org/projects/gcc/} [Último acceso 4/mayo/2021]},
-  title =	 {Página de la aplicación gcc}
+  note =	 {\url{http://savannah.gnu.org/projects/gcc/} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {PÃ¡gina de la aplicaciÃ³n gcc}
 }
 
 
 @Misc{latexdiff,
-  note =	 {\url{http://www.ctan.org/pkg/latexdiff} [Último acceso 22/enero/2021]},
-  title =	 {Página de \texttt{latexdiff} en CTAN}
+  note =	 {\url{http://www.ctan.org/pkg/latexdiff} [Ãšltimo acceso 22/enero/2021]},
+  title =	 {PÃ¡gina de \texttt{latexdiff} en CTAN}
 }
 
 @Misc{git-latexdiff,
-  note =	 {\url{https://gitorious.org/git-latexdiff} [Último acceso 22/enero/2021]},
-  title =	 {Página de \texttt{git-latexdiff} en gitorious}
+  note =	 {\url{https://gitorious.org/git-latexdiff} [Ãšltimo acceso 22/enero/2021]},
+  title =	 {PÃ¡gina de \texttt{git-latexdiff} en gitorious}
 }
 
 
 
 @Misc{gnulinux,
-  note =	 {\url{http://es.wikipedia.org/wiki/GNU/Linux} [Último acceso 4/mayo/2021]},
-  title =	 {Información sobre GNU/Linux en wikipedia}
+  note =	 {\url{http://es.wikipedia.org/wiki/GNU/Linux} [Ãšltimo acceso 4/mayo/2021]},
+  title =	 {InformaciÃ³n sobre GNU/Linux en wikipedia}
 }
 
 @Book{lamport94,
@@ -369,7 +369,7 @@ Practical aspects of microphone array signal processing},
 @Misc{av163,
   OPTkey = 	 {},
   OPTauthor = 	 {},
-  note = 	 {\url{http://mmm.idiap.ch/Lathoud/av16.3\_v6/} [Último acceso 4/mayo/2021]},
+  note = 	 {\url{http://mmm.idiap.ch/Lathoud/av16.3\_v6/} [Ãšltimo acceso 4/mayo/2021]},
   howpublished = {},
   OPTmonth = 	 {},
   OPTyear = 	 {},
@@ -379,7 +379,7 @@ Practical aspects of microphone array signal processing},
 @Misc{ami,
   OPTkey = 	 {},
   OPTauthor = 	 {},
-  note = 	 {\url{http://www.idiap.ch/amicorpus} [Último acceso 4/mayo/2021]},
+  note = 	 {\url{http://www.idiap.ch/amicorpus} [Ãšltimo acceso 4/mayo/2021]},
   howpublished = {},
   OPTmonth = 	 {},
   OPTyear = 	 {},
@@ -403,7 +403,7 @@ Practical aspects of microphone array signal processing},
 @Misc{chil,
   OPTkey = 	 {},
   OPTauthor = 	 {},
-  note = 	 {\url{http://chil.server.de/servlet/is/2712/} [Último acceso 4/mayo/2021]},
+  note = 	 {\url{http://chil.server.de/servlet/is/2712/} [Ãšltimo acceso 4/mayo/2021]},
   howpublished = {},
   OPTmonth = 	 {},
   OPTyear = 	 {},
@@ -414,7 +414,7 @@ Practical aspects of microphone array signal processing},
 @Misc{cmumultimic,
   OPTkey = 	 {},
   author = 	 {Tom Sullivan},
-  note = 	 {\url{http://www.speech.cs.cmu.edu/databases/micarray/index.html} [Último acceso 4/mayo/2021]},
+  note = 	 {\url{http://www.speech.cs.cmu.edu/databases/micarray/index.html} [Ãšltimo acceso 4/mayo/2021]},
   howpublished = {},
   OPTmonth = 	 {},
   OPTyear = 	 {},
@@ -426,7 +426,7 @@ Practical aspects of microphone array signal processing},
 @Misc{icsimrdigits,
   OPTkey = 	 {},
   OPTauthor = 	 {},
-  note = 	 {\url{http://www.icsi.berkeley.edu/Speech/papers/multimic/} [Último acceso 4/mayo/2021]},
+  note = 	 {\url{http://www.icsi.berkeley.edu/Speech/papers/multimic/} [Ãšltimo acceso 4/mayo/2021]},
   howpublished = {},
   OPTmonth = 	 {},
   OPTyear = 	 {},
@@ -438,7 +438,7 @@ Practical aspects of microphone array signal processing},
 @Misc{texis,
   OPTkey = 	 {},
   OPTauthor = 	 {},
-  note = 	 {\url{http://gaia.fdi.ucm.es/projects/texis/} [Último acceso 1/enero/2021]},
+  note = 	 {\url{http://gaia.fdi.ucm.es/projects/texis/} [Ãšltimo acceso 1/enero/2021]},
   howpublished = {},
   OPTmonth = 	 {},
   OPTyear = 	 {},

--- a/Book/biblio/biblio.bib
+++ b/Book/biblio/biblio.bib
@@ -251,7 +251,6 @@ Practical aspects of microphone array signal processing},
   month =	 {October},
   year =	 1990
 }
-@Book{o'shaughnessy50,
 @Book{oshaughnessy50,
   author =	 {Douglas O'Shaughnessy},
   title = 	 {Speech Communication Human and Machine},

--- a/Book/biblio/bibliography.tex
+++ b/Book/biblio/bibliography.tex
@@ -28,30 +28,45 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%\bibliographystyle{plainnat}
-%\bibliographystyle{dinat}
-%\bibliographystyle{unsrt}
-\bibliographystyle{IEEEtran}
+\ifthenelse{\equal{\bibliosystem}{biblatex}}
+{
+  % Use biblatex instead of bibtex
+  % \newcommand{\mybibfileOne}{biblio/biblio.bib}
+  % \addbibresource{\myreferencespath\mybibfileOne}
+  \printbibliography
+}
+{
+  % Use bibtex
 
-% The following is overly complicated because I was not able to do so in
-% another way. The problem is the bibliography command being "called"
-% from both the root and anteproyecto directories...
-%
-% Here define as many bibfiles as needed
-\newcommand{\mybibfileOne}{biblio/biblio.bib}
-%\newcommand{\mybibfileTwo}{biblio/biblio2.bib}
-%...
-%\newcommand{\mybibfileN}{biblio/biblioN}
+  %\bibliographystyle{plainnat}
+  %\bibliographystyle{dinat}
+  %\bibliographystyle{unsrt}
+  \bibliographystyle{IEEEtran}
 
-% This is for a single bib file
-\newcommand{\mybibfiles}{\myreferencespath\mybibfileOne}
-% but do this for multiple files
-%\newcommand{\mybibfiles}{\myreferencespath\mybibfile1,\myreferencespath\mybibfile2,...,\myreferencespath\mybibfileN}
+  % The following is overly complicated because I was not able to do so in
+  % another way. The problem is the bibliography command being "called"
+  % from both the root and anteproyecto directories...
+  %
+  % Here define as many bibfiles as needed
+  \newcommand{\mybibfileOne}{biblio/biblio.bib}
+  %\newcommand{\mybibfileTwo}{biblio/biblio2.bib}
+  %...
+  %\newcommand{\mybibfileN}{biblio/biblioN}
 
-% Do not touch this
-\inputencoding{latin1}
-\bibliography{\mybibfiles}
-\inputencoding{utf8}
+  % This is for a single bib file
+  \newcommand{\mybibfiles}{\myreferencespath\mybibfileOne}
+  % but do this for multiple files
+  %\newcommand{\mybibfiles}{\myreferencespath\mybibfile1,\myreferencespath\mybibfile2,...,\myreferencespath\mybibfileN}
+
+  % Do not touch this
+  \ifpdftex
+  \inputencoding{latin1}
+  \fi
+  \bibliography{\mybibfiles}
+  \ifpdftex
+  \inputencoding{utf8}
+  \fi
+}
 
 %%% Local Variables:
 %%% TeX-master: "../book"

--- a/Book/biblio/bibliography.tex
+++ b/Book/biblio/bibliography.tex
@@ -59,13 +59,7 @@
   %\newcommand{\mybibfiles}{\myreferencespath\mybibfile1,\myreferencespath\mybibfile2,...,\myreferencespath\mybibfileN}
 
   % Do not touch this
-  \ifpdftex
-  \inputencoding{latin1}
-  \fi
   \bibliography{\mybibfiles}
-  \ifpdftex
-  \inputencoding{utf8}
-  \fi
 }
 
 %%% Local Variables:

--- a/Book/biblio/bibliography.tex
+++ b/Book/biblio/bibliography.tex
@@ -33,7 +33,7 @@
   % Use biblatex instead of bibtex
   % \newcommand{\mybibfileOne}{biblio/biblio.bib}
   % \addbibresource{\myreferencespath\mybibfileOne}
-  \printbibliography
+  \printbibliography[heading=bibintoc]
 }
 {
   % Use bibtex

--- a/Book/cover/portada-tfg-uah.tex
+++ b/Book/cover/portada-tfg-uah.tex
@@ -52,7 +52,7 @@
   \node[yshift=-5cm] at (current page.north west)
   {
     \begin{tikzpicture}[remember picture, overlay]
-      \draw[fill=headingPortadaTFG,headingPortadaTFG, fill opacity=.1] (0,0) rectangle (\paperwidth,5cm);
+      \draw[fill=headingPortadaTFG,headingPortadaTFG, fill opacity=1] (0,0) rectangle (\paperwidth,5cm);
       \node [yshift=3cm, xshift=0.5\paperwidth, font=\Huge, text centered, midway] {\color{textoHeadingPortadaTFM}\textbf{\myUniversity}};
       \node [yshift=2cm, xshift=0.5\paperwidth, font=\Huge, text centered, midway] {\color{textoHeadingPortadaTFM}\textbf{\mySchool}};
     \end{tikzpicture}

--- a/Book/cover/portada-tfg-uah.tex
+++ b/Book/cover/portada-tfg-uah.tex
@@ -43,11 +43,16 @@
 % };
 % \end{tikzpicture}
 
+% Add opacity here explicitly see:
+% https://tex.stackexchange.com/questions/649514/how-to-produce-a-transparent-image-with-xelatex/649518#649518
+% https://tex.stackexchange.com/questions/640574/using-a-tikzpicture-disables-opacity-for-first-bgthispage-how-can-i-fix-this
+% Remember to also change the default value in Config/preamble.tex if you need
+% to modify it.
 \begin{tikzpicture}[remember picture,overlay]
   \node[yshift=-5cm] at (current page.north west)
   {
     \begin{tikzpicture}[remember picture, overlay]
-      \draw[fill=headingPortadaTFG,headingPortadaTFG] (0,0) rectangle (\paperwidth,5cm);
+      \draw[fill=headingPortadaTFG,headingPortadaTFG, fill opacity=.1] (0,0) rectangle (\paperwidth,5cm);
       \node [yshift=3cm, xshift=0.5\paperwidth, font=\Huge, text centered, midway] {\color{textoHeadingPortadaTFM}\textbf{\myUniversity}};
       \node [yshift=2cm, xshift=0.5\paperwidth, font=\Huge, text centered, midway] {\color{textoHeadingPortadaTFM}\textbf{\mySchool}};
     \end{tikzpicture}

--- a/Book/slides/Makefile
+++ b/Book/slides/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.2 2014/10/13 12:57:40 macias Exp $
 #
 # By:
-#  + Javier MacÃ­as-Guarasa. 
-#    Departamento de ElectrÃ³nica
-#    Universidad de AlcalÃ¡
+#  + Javier Macías-Guarasa. 
+#    Departamento de Electrónica
+#    Universidad de Alcalá
 #  + Roberto Barra-Chicote. 
-#    Departamento de IngenierÃ­a ElectrÃ³nica
-#    Universidad PolitÃ©cnica de Madrid   
+#    Departamento de Ingeniería Electrónica
+#    Universidad Politécnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel OcaÃ±a, JesÃºs Nuevo,
-# Pedro Revenga, Fernando HerrÃ¡nz and Noelia HernÃ¡ndez. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel Ocaña, Jesús Nuevo,
+# Pedro Revenga, Fernando Herránz and Noelia Hernández. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #
@@ -57,12 +57,12 @@ PDFS_FROM_EPS=$(patsubst %.eps,%.pdf,$(EPS_SOURCES))
 DUMMY_TARGETS=pdf_dia_done pdf_svg_done pdf_eps_done
 
 all: $(DUMMY_TARGETS) $(TEX_FILE)
-	$(RUBBER_TOOL) -f -d $(TEX_FILE)
-	$(RUBBER_TOOL) -f -d $(TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
+	$(PDF_TOOL) $(FLAGS_SYNCTEX_PDFLATEX) $(TEX_FILE)
 
 all_latexmk: $(DUMMY_TARGETS)
-	$(LATEXMK_TOOL) -pdf -pdflatex="pdflatex -interactive=nonstopmode" -use-make $(TEX_FILE)
-	$(LATEXMK_TOOL) -pdf -pdflatex="pdflatex -interactive=nonstopmode" -use-make $(TEX_FILE)
+	$(LATEXMK_TOOL) -$(PDF_PREFIX) -pdflatex="pdflatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -xelatex="xelatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -lualatex="lualatex $(FLAGS_SYNCTEX_PDFLATEX) -interactive=nonstopmode" -use-make $(TEX_FILE)
 
 pdf_dia_done: $(PDFS_FROM_DIA)
 	echo "Generating pdfs from DIA: [$(PDFS_FROM_DIA)]..."

--- a/Book/slides/Makefile
+++ b/Book/slides/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.2 2014/10/13 12:57:40 macias Exp $
 #
 # By:
-#  + Javier Mac�as-Guarasa. 
-#    Departamento de Electr�nica
-#    Universidad de Alcal�
+#  + Javier MacÃ­as-Guarasa. 
+#    Departamento de ElectrÃ³nica
+#    Universidad de AlcalÃ¡
 #  + Roberto Barra-Chicote. 
-#    Departamento de Ingenier�a Electr�nica
-#    Universidad Polit�cnica de Madrid   
+#    Departamento de IngenierÃ­a ElectrÃ³nica
+#    Universidad PolitÃ©cnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel Oca�a, Jes�s Nuevo,
-# Pedro Revenga, Fernando Herr�nz and Noelia Hern�ndez. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel OcaÃ±a, JesÃºs Nuevo,
+# Pedro Revenga, Fernando HerrÃ¡nz and Noelia HernÃ¡ndez. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #

--- a/Book/slides/Makefile
+++ b/Book/slides/Makefile
@@ -34,6 +34,16 @@ LATEXMK_TOOL=latexmk
 EPSPDF_TOOL=epspdf
 RM=rm -f
 
+# PDF_TOOL=pdflatex
+# PDF_TOOL=xelatex
+PDF_TOOL=lualatex
+
+ifeq ($(PDF_TOOL),pdflatex)
+	PDF_PREFIX := $(shell echo $(PDF_TOOL) | sed -e "s/latex//")
+else
+	PDF_PREFIX := pdf$(shell echo $(PDF_TOOL) | sed -e "s/latex//" )
+endif
+
 ###########################################################################
 # Support to automagically compile dia+svg files. Adapt to your own needs
 DIA_SOURCES=$(wildcard ../diagrams/*.dia)

--- a/Book/slides/documentation/beamer/Beamer/Vortrag/preambel/Beamer-LaTeX-Settings.tex
+++ b/Book/slides/documentation/beamer/Beamer/Vortrag/preambel/Beamer-LaTeX-Settings.tex
@@ -1,6 +1,9 @@
 % *** Sprache *****************************
 \usepackage[ngerman]{babel}
-\usepackage[latin1]{inputenc}
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[latin1]{inputenc} % Para poder escribir con acentos y ñ.
+\fi                                % usar si no es necesario, porque ralentiza muchisimo la compilación.
 %------------------------------------------
 
 

--- a/Book/slides/slides.tex
+++ b/Book/slides/slides.tex
@@ -10,10 +10,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
 % BEGIN Preamble and configuration section
 % 
-\input{../config/preamble-slides.tex}    % DO NOT TOUCH THIS LINE. You can edit
+\input{../../Config/preamble-slides.tex}    % DO NOT TOUCH THIS LINE. You can edit
 % the file to modify some default settings
 
-\input{../config/myconfig.tex}    % DO NOT TOUCH THIS LINE, but EDIT THIS FILE 
+\input{../../Config/myconfig.tex}    % DO NOT TOUCH THIS LINE, but EDIT THIS FILE 
                                   % to set your specific settings (related
                                   % to the document language, your degree,
                                   % document details (such as title, author
@@ -23,7 +23,7 @@
                                   % define your commonly used commands
                                   % (some examples are provided).
 
-\input{../config/postamble.tex}   % DO NOT TOUCH THIS LINE. Yes, I know,
+\input{../../Config/postamble.tex}   % DO NOT TOUCH THIS LINE. Yes, I know,
                                   % "postamble" is not a valid word... :-)
 
 % path to directories containing images

--- a/Config/postamble.tex
+++ b/Config/postamble.tex
@@ -702,7 +702,7 @@
   % pdfkeywords={\myThesisKeywords, \myWorkTypeFull, \myDegreefull},
   pdfkeywords={\keywordsforpdf},
   pdfcreator={\LaTeX with hyperref package},
-  pdfproducer={rubber},
+  % pdfproducer={rubber},
   pdffitwindow={true},
   % This can be set in myconfig.tex
   urlcolor=\myurlcolor,

--- a/Config/preamble-anteproyecto.tex
+++ b/Config/preamble-anteproyecto.tex
@@ -38,11 +38,15 @@
 %% FIXING PROBLEM WITH ALL PAGES PRINTED IN COLOR
 %\PassOptionsToPackage{cmyk}{xcolor}% NB: put this *before* \usepackage{pst-all}
 
-\usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
-\usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
-                              % usar si no es necesario, porque ralentiza muchisimo la compilación.
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
+  \usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
+\fi                             % usar si no es necesario, porque ralentiza muchisimo la compilación.
 \usepackage{ae}               % Para que todas las fuentes sean Type1, y ninguna Type3.
-\usepackage{cmap}
+\ifPDFTeX
+  \usepackage{cmap} % This package produces an error if we are not using pdflatex
+\fi
 \usepackage[spanish, english]{babel}
 
 % Use this if you want to include pdf files in the final document

--- a/Config/preamble-anteproyecto.tex
+++ b/Config/preamble-anteproyecto.tex
@@ -508,8 +508,8 @@ pdfborder={0 0 112.0}              %%% border-width of frames
 % visited date, in the .bib file). It also support multiple files more easily
 % and more bibliography styles
 
-\newcommand{\bibliosystem}{bibtex} % Valid options are biblatex or bibtex
-% \newcommand{\bibliosystem}{biblatex} % Valid options are biblatex or bibtex
+% \newcommand{\bibliosystem}{bibtex} % Valid options are biblatex or bibtex
+\newcommand{\bibliosystem}{biblatex} % Valid options are biblatex or bibtex
 
 \ifthenelse{\equal{\bibliosystem}{biblatex}}
 {

--- a/Config/preamble-anteproyecto.tex
+++ b/Config/preamble-anteproyecto.tex
@@ -340,6 +340,34 @@ pdfborder={0 0 112.0}              %%% border-width of frames
 \floatstyle{plaintop} % optionally change the style of the new float
 %\newfloat{codefloat}{H}{cod}[chapter]
 
+% Support utf-8 in listings. 
+% The way the inputenc package works with non-ASCII UTF-8-encoded characters (by
+% making the first byte active and then reading the following ones as arguments)
+% is fundamentally incompatible with the way the listing package works, which
+% reads each byte individually and expects it to be an individual character.
+% See https://tex.stackexchange.com/questions/24528/having-problems-with-listings-and-utf-8-can-it-be-fixed
+\lstset{
+    inputencoding = utf8,  % Input encoding
+    extendedchars = true,  % Extended ASCII
+    literate      =        % Support additional characters
+      {á}{{\'a}}1  {é}{{\'e}}1  {í}{{\'i}}1 {ó}{{\'o}}1  {ú}{{\'u}}1
+      {Á}{{\'A}}1  {É}{{\'E}}1  {Í}{{\'I}}1 {Ó}{{\'O}}1  {Ú}{{\'U}}1
+      {à}{{\`a}}1  {è}{{\`e}}1  {ì}{{\`i}}1 {ò}{{\`o}}1  {ù}{{\`u}}1
+      {À}{{\`A}}1  {È}{{\'E}}1  {Ì}{{\`I}}1 {Ò}{{\`O}}1  {Ù}{{\`U}}1
+      {ä}{{\"a}}1  {ë}{{\"e}}1  {ï}{{\"i}}1 {ö}{{\"o}}1  {ü}{{\"u}}1
+      {Ä}{{\"A}}1  {Ë}{{\"E}}1  {Ï}{{\"I}}1 {Ö}{{\"O}}1  {Ü}{{\"U}}1
+      {â}{{\^a}}1  {ê}{{\^e}}1  {î}{{\^i}}1 {ô}{{\^o}}1  {û}{{\^u}}1
+      {Â}{{\^A}}1  {Ê}{{\^E}}1  {Î}{{\^I}}1 {Ô}{{\^O}}1  {Û}{{\^U}}1
+      {œ}{{\oe}}1  {Œ}{{\OE}}1  {æ}{{\ae}}1 {Æ}{{\AE}}1  {ß}{{\ss}}1
+      {ç}{{\c c}}1 {Ç}{{\c C}}1 {ø}{{\o}}1  {Ø}{{\O}}1   {å}{{\r a}}1
+      {Å}{{\r A}}1 {ã}{{\~a}}1  {õ}{{\~o}}1 {Ã}{{\~A}}1  {Õ}{{\~O}}1
+      {ñ}{{\~n}}1  {Ñ}{{\~N}}1  {¿}{{?`}}1  {¡}{{!`}}1
+      {°}{{\textdegree}}1 {º}{{\textordmasculine}}1 {ª}{{\textordfeminine}}1
+      % ¿ and ¡ are not correctly displayed if inconsolata font is used
+      % together with the lstlisting environment. Consider typing code in
+      % external files and using \lstinputlisting to display them instead.      
+  }
+
 \lstdefinestyle{console}
                {
                  basicstyle=\scriptsize\bf\ttfamily,

--- a/Config/preamble-anteproyecto.tex
+++ b/Config/preamble-anteproyecto.tex
@@ -72,23 +72,6 @@
 \usepackage{supertabular}
 \usepackage{hhline}
 \usepackage{array}
-\usepackage[noadjust]{cite}      % Written by Donald Arseneau
-                        % V1.6 and later of IEEEtran pre-defines the format
-                        % of the cite.sty package \cite{} output to follow
-                        % that of IEEE. Loading the cite package will
-                        % result in citation numbers being automatically
-                        % sorted and properly "ranged". i.e.,
-                        % [1], [9], [2], [7], [5], [6]
-                        % (without using cite.sty)
-                        % will become:
-                        % [1], [2], [5]--[7], [9] (using cite.sty)
-                        % cite.sty's \cite will automatically add leading
-                        % space, if needed. Use cite.sty's noadjust option
-                        % (cite.sty V3.8 and later) if you want to turn this
-                        % off. cite.sty is already installed on most LaTeX
-                        % systems. The latest version can be obtained at:
-                        % http://www.ctan.org/tex-archive/macros/latex/contrib/supported/cite/
-
 
 \usepackage{caption}
 
@@ -515,6 +498,42 @@ pdfborder={0 0 112.0}              %%% border-width of frames
 \providecommand{\DIFadd}[1]{{\protect\color{blue}\textbf{#1}}}
 \providecommand{\DIFdel}[1]{{\protect\color{red}\sout{#1}}}                     
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Bibliography backend control. It is recommended  that we use biblatex, as it
+% supports more keys (for example, when we cite a website we can specify the
+% visited date, in the .bib file). It also support multiple files more easily
+% and more bibliography styles
+
+\newcommand{\bibliosystem}{bibtex} % Valid options are biblatex or bibtex
+% \newcommand{\bibliosystem}{biblatex} % Valid options are biblatex or bibtex
+
+\ifthenelse{\equal{\bibliosystem}{biblatex}}
+{
+  % Use biblatex instead of bibtex
+  \usepackage[style=ieee]{biblatex}
+  % \newcommand{\mybibfileOne}{biblio/biblio.bib}
+  % \addbibresource{\myreferencespath\mybibfileOne}
+  \addbibresource{../Book/biblio/biblio.bib}
+}
+{
+  % Use bibtex
+  \usepackage[noadjust]{cite}      % Written by Donald Arseneau
+  % V1.6 and later of IEEEtran pre-defines the format
+  % of the cite.sty package \cite{} output to follow
+  % that of IEEE. Loading the cite package will
+  % result in citation numbers being automatically
+  % sorted and properly "ranged". i.e.,
+  % [1], [9], [2], [7], [5], [6]
+  % (without using cite.sty)
+  % will become:
+  % [1], [2], [5]--[7], [9] (using cite.sty)
+  % cite.sty's \cite will automatically add leading
+  % space, if needed. Use cite.sty's noadjust option
+  % (cite.sty V3.8 and later) if you want to turn this
+  % off. cite.sty is already installed on most LaTeX
+  % systems. The latest version can be obtained at:
+  % http://www.ctan.org/tex-archive/macros/latex/contrib/supported/cite/
+}
 %%% Local Variables:
 %%% TeX-master: "../book"
 %%% End:

--- a/Config/preamble-letter.tex
+++ b/Config/preamble-letter.tex
@@ -37,10 +37,11 @@
 
 % ifthen to allow using language dependent settings
 \usepackage{ifthen}
-
-\usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
-\usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
-                              % usar si no es necesario, porque ralentiza muchisimo la compilación.
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
+  \usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
+\fi                                % usar si no es necesario, porque ralentiza muchisimo la compilación.
 \usepackage{ae}               % Para que todas las fuentes sean Type1, y ninguna Type3.
 
 \usepackage[spanish, english]{babel}

--- a/Config/preamble-slides.tex
+++ b/Config/preamble-slides.tex
@@ -368,7 +368,7 @@
 \definecolor{titlecolor}{RGB}{0,173,239}
 
 \mode<presentation>{
-  % % \usetheme{Warsaw}
+  % \usetheme{Warsaw}
   % \usefonttheme{structurebold}
   % \setbeamerfont{title}{family={\fontfamily{ppl}},series=\bfseries,size=\LARGE,shape=\itshape}
   
@@ -386,47 +386,51 @@
   
   \setbeamertemplate{navigation symbols}{}
 
+  % \setbeamertemplate{itemize items}[square]
 
-%  \setbeamertemplate{itemize items}[square]
+  \transduration{1}
+  % \addtobeamertemplate{background canvas}{\transuncover[duration=1,direction=270]}{}
+  % \addtobeamertemplate{background canvas}{\transdissolve[duration=0.5,direction=90]}{}
+  % \addtobeamertemplate{background canvas}{\transglitter[direction=90]}{}
 
-\transduration{1}
-%\addtobeamertemplate{background canvas}{\transuncover[duration=1,direction=270]}{}
-%\addtobeamertemplate{background canvas}{\transdissolve[duration=0.5,direction=90]}{}
-%\addtobeamertemplate{background canvas}{\transglitter[direction=90]}{}
+  \setbeamertemplate{frametitle}{\Large\insertframetitle\\\large\textcolor{blue}{\insertframesubtitle}}
 
-\setbeamertemplate{frametitle}{\Large\insertframetitle\\\large\textcolor{blue}{\insertframesubtitle}}
+  \setbeamercolor{item}{fg=red} % color of bullets
+  \setbeamertemplate{itemize item}{$\bm{\Box}$}
+  \setbeamercolor{itemize/enumerate body}{fg=black}
 
-\setbeamercolor{item}{fg=red} % color of bullets
-\setbeamertemplate{itemize item}{$\bm{\Box}$}
-\setbeamercolor{itemize/enumerate body}{fg=black}
+  \setbeamertemplate{itemize subitem}{\scriptsize$\blacksquare$}
+  % Fix compilation error in modern latex the shape key does not exists
+  % \setbeamercolor{itemize/enumerate subbody}{fg=blue,shape=\itshape}
+  \setbeamercolor{itemize/enumerate subbody}{fg=blue}
 
-\setbeamertemplate{itemize subitem}{\scriptsize$\blacksquare$}
-\setbeamercolor{itemize/enumerate subbody}{fg=blue,shape=\itshape}
+  \setbeamertemplate{itemize subsubitem}{\tiny$\Box$}
+  % Fix compilation error in modern latex the shape key does not exists
+  % \setbeamercolor{itemize/enumerate subsubbody}{fg=red,shape=\itshape}
+  \setbeamercolor{itemize/enumerate subsubbody}{fg=red}
 
-\setbeamertemplate{itemize subsubitem}{\tiny$\Box$}
-\setbeamercolor{itemize/enumerate subsubbody}{fg=red,shape=\itshape}
+  \setbeamercolor{frametitle}{fg=black}
+  \setbeamercolor{framesubtitle}{fg=blue}
+  \setbeamerfont{framesubtitle}{size=\Large}
 
-\setbeamercolor{frametitle}{fg=black}
-\setbeamercolor{framesubtitle}{fg=blue}
-\setbeamerfont{framesubtitle}{size=\Large}
+  %\setbeamercolor{subitem}{fg=red}
+  %\setbeamercolor{itemize/enumerate subbody}{fg=gray}
+  %\setbeamertemplate{itemize subitem}{{\textendash}}
+  %\setbeamerfont{itemize/enumerate subbody}{size=\footnotesize}
+  %\setbeamerfont{itemize/enumerate subitem}{size=\footnotesize}
 
-
-%\setbeamercolor{subitem}{fg=red}
-%\setbeamercolor{itemize/enumerate subbody}{fg=gray}
-%\setbeamertemplate{itemize subitem}{{\textendash}}
-%\setbeamerfont{itemize/enumerate subbody}{size=\footnotesize}
-%\setbeamerfont{itemize/enumerate subitem}{size=\footnotesize}
-
-%   \setbeamertemplate{itemize items}{\scriptsize\raise1.25pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
-%   \setbeamertemplate{itemize subitems}{\tiny\raise1.5pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
-%   \setbeamertemplate{itemize subsubitems}{\tiny\raise1.5pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
+  % \setbeamertemplate{itemize items}{\scriptsize\raise1.25pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
+  % \setbeamertemplate{itemize subitems}{\tiny\raise1.5pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
+  % \setbeamertemplate{itemize subsubitems}{\tiny\raise1.5pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
   % \setbeamertemplate{enumerate items}{\insertenumlabel.}
   % \setbeamertemplate{enumerate subitems}{\insertenumlabel.\insertsubenumlabel}
   % \setbeamertemplate{enumerate subsubitems}{\insertenumlabel.\insertsubenumlabel.\insertsubsubenumlabel}
   % \setbeamertemplate{enumerate mini template}{\insertenumlabel}
   
   \let\Tiny=\tiny
-  \setbeamersize{text margin left=0.3cm,text margin right=0.3cm, text margin top=0.3cm, text margin bottom=0.3cm}
+  % Fix compilation error in modern latex the margin top/bottom keys don't exists
+  % \setbeamersize{text margin left=0.3cm,text margin right=0.3cm, text margin top=0.3cm, text margin bottom=0.3cm}
+  \setbeamersize{text margin left=0.3cm,text margin right=0.3cm}
 }
 
 \addtobeamertemplate{title page}{}{%

--- a/Config/preamble-slides.tex
+++ b/Config/preamble-slides.tex
@@ -30,10 +30,11 @@
 
 % ifthen to allow using language dependent settings
 \usepackage{ifthen}
-
-\usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
-\usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
-                              % usar si no es necesario, porque ralentiza muchisimo la compilación.
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
+  \usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
+\fi                                % usar si no es necesario, porque ralentiza muchisimo la compilación.
 \usepackage{ae}               % Para que todas las fuentes sean Type1, y ninguna Type3.
 \usepackage{lmodern}          % This generates a pdf with searchable
                               % accented characters!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/Config/preamble-solicitud.tex
+++ b/Config/preamble-solicitud.tex
@@ -38,9 +38,12 @@
 %% FIXING PROBLEM WITH ALL PAGES PRINTED IN COLOR
 %\PassOptionsToPackage{cmyk}{xcolor}% NB: put this *before* \usepackage{pst-all}
 
-\usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
-\usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
-                              % usar si no es necesario, porque ralentiza muchisimo la compilación.
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
+  \usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
+\fi                                % usar si no es necesario, porque ralentiza muchisimo la compilación.
+
 \usepackage{ae}               % Para que todas las fuentes sean Type1, y ninguna Type3.
 
 \usepackage[spanish, english]{babel}

--- a/Config/preamble.tex
+++ b/Config/preamble.tex
@@ -361,6 +361,10 @@ hyperfootnotes=false,
 %\usepackage[pages=some]{sty/background}
 \usepackage[pages=some]{background}
 
+% Note that we also set the opacity in the first page of the tfg due to a bug,
+% so it you modify it here remember to modify the value in Book/cover/portada-tfm-uah.tex
+% https://tex.stackexchange.com/questions/649514/how-to-produce-a-transparent-image-with-xelatex/649518#649518
+% https://tex.stackexchange.com/questions/640574/using-a-tikzpicture-disables-opacity-for-first-bgthispage-how-can-i-fix-this
 \ifthenelse{\equal{\colorspaceused}{rgb}}
 {
   \backgroundsetup{ scale=1, angle=0, opacity=.1, color=pink,

--- a/Config/preamble.tex
+++ b/Config/preamble.tex
@@ -58,11 +58,13 @@
   \PassOptionsToPackage{cmyk}{xcolor}% NB: put this *before* \usepackage{pst-all}
 }
 
+\usepackage{iftex}
 %\usepackage[latin1]{inputenc} % Para poder escribir con acentos y ñ. en
                               % latin1
-\usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ. en utf8
-\usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
-                              % usar si no es necesario, porque ralentiza muchisimo la compilación.
+\ifPDFTeX
+  \usepackage[utf8]{inputenc} % Para poder escribir con acentos y ñ.
+  \usepackage[T1]{fontenc}      % Para que haga bien la ``hyphenation''. No
+\fi                                % usar si no es necesario, porque ralentiza muchisimo la compilación.
 \usepackage{ae}               % Para que todas las fuentes sean Type1, y ninguna Type3.
 \usepackage{lmodern}          % This generates a pdf with searchable
                               % accented characters!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/Config/preamble.tex
+++ b/Config/preamble.tex
@@ -98,22 +98,6 @@
 \usepackage{supertabular}
 \usepackage{hhline}
 \usepackage{array}
-\usepackage[noadjust]{cite}      % Written by Donald Arseneau
-% V1.6 and later of IEEEtran pre-defines the format
-% of the cite.sty package \cite{} output to follow
-% that of IEEE. Loading the cite package will
-% result in citation numbers being automatically
-% sorted and properly "ranged". i.e.,
-% [1], [9], [2], [7], [5], [6]
-% (without using cite.sty)
-% will become:
-% [1], [2], [5]--[7], [9] (using cite.sty)
-% cite.sty's \cite will automatically add leading
-% space, if needed. Use cite.sty's noadjust option
-% (cite.sty V3.8 and later) if you want to turn this
-% off. cite.sty is already installed on most LaTeX
-% systems. The latest version can be obtained at:
-% http://www.ctan.org/tex-archive/macros/latex/contrib/supported/cite/
 
 
 \usepackage[center]{caption}
@@ -625,13 +609,41 @@ hyperfootnotes=false,
 \appto{\appendices}{\def\Hy@chapapp{Appendix}}
 \makeatother
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Bibliography backend control. It is recommended  that we use biblatex, as it
+% supports more keys (for example, when we cite a website we can specify the
+% visited date, in the .bib file). It also support multiple files more easily
+% and more bibliography styles
 
-% Comments. Here you should change JMG, MAS to follow the initials of
-% the involved reviewers (usually the author and the advisor(s))
-\newcommand{\todosidejmg}{\todo[author=JMG, noinline, color=red!40]}
-\newcommand{\todosidemas}{\todo[author=MAS, noinline, color=blue!60]}
-\newcommand{\todojmg}{\todo[author=JMG, inline, color=red!40]}
-\newcommand{\todomas}{\todo[author=MAS, inline, color=blue!60]}
+% \newcommand{\bibliosystem}{bibtex} % Valid options are biblatex or bibtex
+\newcommand{\bibliosystem}{biblatex} % Valid options are biblatex or bibtex
+
+\ifthenelse{\equal{\bibliosystem}{biblatex}}
+{
+  % Use biblatex instead of bibtex
+  \usepackage[style=ieee]{biblatex}
+  \newcommand{\mybibfileOne}{biblio/biblio.bib}
+  \addbibresource{\myreferencespath\mybibfileOne}
+}
+{
+  % Use bibtex
+  \usepackage[noadjust]{cite}      % Written by Donald Arseneau
+  % V1.6 and later of IEEEtran pre-defines the format
+  % of the cite.sty package \cite{} output to follow
+  % that of IEEE. Loading the cite package will
+  % result in citation numbers being automatically
+  % sorted and properly "ranged". i.e.,
+  % [1], [9], [2], [7], [5], [6]
+  % (without using cite.sty)
+  % will become:
+  % [1], [2], [5]--[7], [9] (using cite.sty)
+  % cite.sty's \cite will automatically add leading
+  % space, if needed. Use cite.sty's noadjust option
+  % (cite.sty V3.8 and later) if you want to turn this
+  % off. cite.sty is already installed on most LaTeX
+  % systems. The latest version can be obtained at:
+  % http://www.ctan.org/tex-archive/macros/latex/contrib/supported/cite/
+}
 
 %%% Local Variables:
 %%% TeX-master: "../book"

--- a/Config/preamble.tex
+++ b/Config/preamble.tex
@@ -404,6 +404,34 @@ hyperfootnotes=false,
 \floatstyle{plaintop} % optionally change the style of the new float
 \newfloat{codefloat}{H}{cod}[chapter]
 
+% Support utf-8 in listings. 
+% The way the inputenc package works with non-ASCII UTF-8-encoded characters (by
+% making the first byte active and then reading the following ones as arguments)
+% is fundamentally incompatible with the way the listing package works, which
+% reads each byte individually and expects it to be an individual character.
+% See https://tex.stackexchange.com/questions/24528/having-problems-with-listings-and-utf-8-can-it-be-fixed
+\lstset{
+    inputencoding = utf8,  % Input encoding
+    extendedchars = true,  % Extended ASCII
+    literate      =        % Support additional characters
+      {á}{{\'a}}1  {é}{{\'e}}1  {í}{{\'i}}1 {ó}{{\'o}}1  {ú}{{\'u}}1
+      {Á}{{\'A}}1  {É}{{\'E}}1  {Í}{{\'I}}1 {Ó}{{\'O}}1  {Ú}{{\'U}}1
+      {à}{{\`a}}1  {è}{{\`e}}1  {ì}{{\`i}}1 {ò}{{\`o}}1  {ù}{{\`u}}1
+      {À}{{\`A}}1  {È}{{\'E}}1  {Ì}{{\`I}}1 {Ò}{{\`O}}1  {Ù}{{\`U}}1
+      {ä}{{\"a}}1  {ë}{{\"e}}1  {ï}{{\"i}}1 {ö}{{\"o}}1  {ü}{{\"u}}1
+      {Ä}{{\"A}}1  {Ë}{{\"E}}1  {Ï}{{\"I}}1 {Ö}{{\"O}}1  {Ü}{{\"U}}1
+      {â}{{\^a}}1  {ê}{{\^e}}1  {î}{{\^i}}1 {ô}{{\^o}}1  {û}{{\^u}}1
+      {Â}{{\^A}}1  {Ê}{{\^E}}1  {Î}{{\^I}}1 {Ô}{{\^O}}1  {Û}{{\^U}}1
+      {œ}{{\oe}}1  {Œ}{{\OE}}1  {æ}{{\ae}}1 {Æ}{{\AE}}1  {ß}{{\ss}}1
+      {ç}{{\c c}}1 {Ç}{{\c C}}1 {ø}{{\o}}1  {Ø}{{\O}}1   {å}{{\r a}}1
+      {Å}{{\r A}}1 {ã}{{\~a}}1  {õ}{{\~o}}1 {Ã}{{\~A}}1  {Õ}{{\~O}}1
+      {ñ}{{\~n}}1  {Ñ}{{\~N}}1  {¿}{{?`}}1  {¡}{{!`}}1
+      {°}{{\textdegree}}1 {º}{{\textordmasculine}}1 {ª}{{\textordfeminine}}1
+      % ¿ and ¡ are not correctly displayed if inconsolata font is used
+      % together with the lstlisting environment. Consider typing code in
+      % external files and using \lstinputlisting to display them instead.      
+  }
+
 \lstdefinestyle{console}
 {
   basicstyle=\scriptsize\bf\ttfamily,

--- a/Deprecated/solicitud/Makefile
+++ b/Deprecated/solicitud/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.4 2016/07/14 23:38:15 macias Exp $
 #
 # By:
-#  + Javier Macías-Guarasa. 
-#    Departamento de Electrónica
-#    Universidad de Alcalá
+#  + Javier MacÃ­as-Guarasa. 
+#    Departamento de ElectrÃ³nica
+#    Universidad de AlcalÃ¡
 #  + Roberto Barra-Chicote. 
-#    Departamento de Ingeniería Electrónica
-#    Universidad Politécnica de Madrid   
+#    Departamento de IngenierÃ­a ElectrÃ³nica
+#    Universidad PolitÃ©cnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel Ocaña, Jesús Nuevo,
-# Pedro Revenga, Fernando Herránz and Noelia Hernández. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel OcaÃ±a, JesÃºs Nuevo,
+# Pedro Revenga, Fernando HerrÃ¡nz and Noelia HernÃ¡ndez. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #

--- a/Papeleo/SolicitudTFGTFM/Makefile
+++ b/Papeleo/SolicitudTFGTFM/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.3 2016/06/22 23:27:41 macias Exp $
 #
 # By:
-#  + Javier Macías-Guarasa. 
-#    Departamento de Electrónica
-#    Universidad de Alcalá
+#  + Javier MacÃ­as-Guarasa. 
+#    Departamento de ElectrÃ³nica
+#    Universidad de AlcalÃ¡
 #  + Roberto Barra-Chicote. 
-#    Departamento de Ingeniería Electrónica
-#    Universidad Politécnica de Madrid   
+#    Departamento de IngenierÃ­a ElectrÃ³nica
+#    Universidad PolitÃ©cnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel Ocaña, Jesús Nuevo,
-# Pedro Revenga, Fernando Herránz and Noelia Hernández. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel OcaÃ±a, JesÃºs Nuevo,
+# Pedro Revenga, Fernando HerrÃ¡nz and Noelia HernÃ¡ndez. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #

--- a/Papeleo/TFMAutorizacionPubAbierto/Makefile
+++ b/Papeleo/TFMAutorizacionPubAbierto/Makefile
@@ -5,15 +5,15 @@
 # $Id: Makefile,v 1.3 2016/06/22 23:27:41 macias Exp $
 #
 # By:
-#  + Javier Macías-Guarasa. 
-#    Departamento de Electrónica
-#    Universidad de Alcalá
+#  + Javier MacÃ­as-Guarasa. 
+#    Departamento de ElectrÃ³nica
+#    Universidad de AlcalÃ¡
 #  + Roberto Barra-Chicote. 
-#    Departamento de Ingeniería Electrónica
-#    Universidad Politécnica de Madrid   
+#    Departamento de IngenierÃ­a ElectrÃ³nica
+#    Universidad PolitÃ©cnica de Madrid   
 # 
-# Based on original sources by Roberto Barra, Manuel Ocaña, Jesús Nuevo,
-# Pedro Revenga, Fernando Herránz and Noelia Hernández. Thanks a lot to
+# Based on original sources by Roberto Barra, Manuel OcaÃ±a, JesÃºs Nuevo,
+# Pedro Revenga, Fernando HerrÃ¡nz and Noelia HernÃ¡ndez. Thanks a lot to
 # all of them, and to the many anonymous contributors found (thanks to
 # google) that provided help in setting all this up.
 #


### PR DESCRIPTION
In this PR we improve the utf-8 support, by fully converting the template to
this encoding. We are able to support an utf-8 bibliography by using the
biblatex package and the biber program instead of the bibtex suite to process
the bibliography files.

Biber allows us to process utf-8 files natively, but it has some trade-offs that
are documented on these links:
https://tex.stackexchange.com/questions/25701/bibtex-vs-biber-and-biblatex-vs-natbib
https://tex.stackexchange.com/questions/53247/why-is-biber-so-slow

We also allow the compilation of the document with modern backends that support
utf-8 by default, namely xelatex and lualatex, but we maintain the old defaults
by using pdflatex in the makefiles.

Lastly we also have deleted the support for rubber in the main makefiles and
fixed the slides compilation.

We have decided to defer the update of the code inclusion backend and some fixes 
for the use of glossaries on overleaf to a future update.